### PR TITLE
Added admin channel commands

### DIFF
--- a/lib/Commands/archive.ts
+++ b/lib/Commands/archive.ts
@@ -1,0 +1,102 @@
+/**
+ *
+ * N3rdP1um23
+ * November 18, 2020
+ * The following file is used to handle archiving the respective channel
+ *
+ */
+
+// Import the requried items
+import * as Discord from 'discord.js';
+import { AnyARecord } from 'dns';
+import * as db from '../../database';
+
+/**
+ *
+ * The following function is used to handle archiving the respective channel
+ *
+ * @param message: is the message to handle
+ * @param args: is the array of events
+ *
+ */
+export function archiveChannel(message: Discord.Message, args) {
+    // Check to see if no parameters were passed
+	if(args.length === 1 && (args[0] !== 'true' && args[0] !== 'false')) {
+		// React with a question mark as the user hasn't entered a valid option and then return to stop further processing
+		message.react('❓');
+		return;
+	}
+
+	// Create the required variables
+	var archive_category_channel;
+
+	// Check to see if there's an archive category
+	db.getConfig('archive_category_id').then(async (result) => {
+		// Check to make sure the value isn't undefined
+		if(result !== undefined) {
+			// Grab the archived category channel
+			archive_category_channel = message.guild.channels.cache.find(channel => channel.id === result);
+		}else{
+			// Create the required variables
+			var category_channels = message.guild.channels.cache.filter(channel => channel.type === 'category');
+			var existing_archive_channel = category_channels.find(channel => channel.name.toLowerCase().includes('archive'));
+
+			// Check to see if an existing channel wasn't found
+			if(existing_archive_channel === undefined) {
+				// Create the archive channel
+				await message.guild.channels.create('📁 Archived', {type: 'category', topic: `Holds all archived channels from the server`}).then((channel) => {
+					// Grab the respective roles
+					const everyone = message.guild.roles.cache.find(role => role.name.toLowerCase() === "@" + "everyone");
+					const admin = message.guild.roles.cache.find(role => role.name.toLowerCase() === "admin");
+					const mod = message.guild.roles.cache.find(role => role.name.toLowerCase() === "moderator");
+
+					// Update the permissions for the category
+					channel.overwritePermissions([
+						{
+							id: everyone.id,
+							deny: ['VIEW_CHANNEL'],
+						},
+						{
+							id: admin.id,
+							allow: ['VIEW_CHANNEL'],
+						},
+						{
+							id: mod.id,
+							allow: ['VIEW_CHANNEL'],
+						}
+					], 'Hide everyone access from the category and only allow Admins and Mods to view.');
+
+					// Update the archived_category_channel variable
+					archive_category_channel = channel;
+				});
+			}else{
+				// Set the archive channel
+				archive_category_channel = existing_archive_channel;
+			}
+
+			// Make the category and then store the id in the database
+			await db.updateConfig('archive_category_id', archive_category_channel.id);
+		}
+
+		// Grab the current channel in question
+		var current_channel = message.guild.channels.cache.find(channel => channel.id === message.channel.id);
+
+		// Check to see if the channel is already archived
+		if(current_channel.parent.id === archive_category_channel.id) {
+			// Send an error message that the channel is already archived
+			message.channel.send('This channel is already archived! (╯°□°）╯︵ ┻━┻');
+		}else{
+			// Check to see if the channel should be recreated
+			if(args[0] === 'true') {
+				// Clone the channel
+				await current_channel.clone();
+			}
+
+			// Handle updateing the respective channel
+			current_channel.setParent(archive_category_channel.id, { lockPermissions: true }).then(() => message.channel.send('This channel has now been archived!')).catch(console.error);
+		}
+	});
+
+    // Return to stop further processing
+    return;
+}

--- a/lib/Commands/archive.ts
+++ b/lib/Commands/archive.ts
@@ -64,7 +64,7 @@ export function archiveChannel(message: Discord.Message, args) {
 							id: mod.id,
 							allow: ['VIEW_CHANNEL'],
 						}
-					], 'Hide everyone access from the category and only allow Admins and Mods to view.');
+					], 'Hide everyone\'s access from this category and only allow Admins and Mods to view.');
 
 					// Update the archived_category_channel variable
 					archive_category_channel = channel;
@@ -86,14 +86,37 @@ export function archiveChannel(message: Discord.Message, args) {
 			// Send an error message that the channel is already archived
 			message.channel.send('This channel is already archived! (╯°□°）╯︵ ┻━┻');
 		}else{
-			// Check to see if the channel should be recreated
+			// Create a variable that will hold the clonsed channel
+			var cloned_channel;
+
+			// Check to see if the channel should be cloned
 			if(args[0] === 'true') {
 				// Clone the channel
-				await current_channel.clone();
+				cloned_channel = await current_channel.clone();
 			}
 
+			// Formulate the archive embed
+			let archive_embed = {
+				embed: {
+					title: `Channel Archived`,
+					description: `This channel has now been archived.`,
+					color: 4886754,
+					timestamp: new Date(),
+					fields: [
+						{
+							name: "Was the channel cloned?",
+							value: `${(args[0] === 'true') ? `\`Yes - New Channel\` <#${cloned_channel.id}>` : '\`\`\`No\`\`\`'}`,
+						},
+						{
+							name: "Archived by",
+							value: `<@${message.member.user.id}>`,
+						}
+					]
+				}
+			};
+
 			// Handle updateing the respective channel
-			current_channel.setParent(archive_category_channel.id, { lockPermissions: true }).then(() => message.channel.send('This channel has now been archived!')).catch(console.error);
+			current_channel.setParent(archive_category_channel.id, { lockPermissions: true }).then(() => message.channel.send(archive_embed)).catch(console.error);
 		}
 	});
 

--- a/lib/Commands/channel.ts
+++ b/lib/Commands/channel.ts
@@ -139,6 +139,7 @@ export function archive(message: Discord.Message, args) {
 export async function clone(message: Discord.Message, args) {
 	// Grab the current channel in question
 	var current_channel = message.guild.channels.cache.find(channel => channel.id === message.channel.id);
+
 	// Create a variable that will hold the clonsed channel
 	var cloned_channel;
 
@@ -175,6 +176,41 @@ export async function clone(message: Discord.Message, args) {
 
 	// Send the notive to the channel
 	message.channel.send(clone_embed);
+
+    // Return to stop further processing
+    return;
+}
+
+/**
+ *
+ * The following function is used to handle removing the respective channel
+ *
+ * @param message: is the message to handle
+ * @param message: is the passed parameters
+ *
+ */
+export async function remove(message: Discord.Message, args) {
+	// Grab the current channel in question
+	var current_channel = message.guild.channels.cache.find(channel => channel.id === message.channel.id);
+
+	// Confirm with the user that they want to actually remove the channel
+	message.reply('The bot will now remove this channel.\nConfirm with `yes` or deny with `no`.');
+
+	// Await for a reply - must be send from the OG user, only accept one message, and await fro 30s
+	message.channel.awaitMessages(m => m.author.id == message.author.id, {max: 1, time: 30000}).then(async response => {
+		// first (and, in this case, only) message of the collection
+		if(response.first().content.toLowerCase() === 'yes') {
+			// Response with a message and then remove the channel
+			message.reply('Removing channel...');
+			await current_channel.delete();
+		}else{
+			// Reply with a failed message
+			message.reply('Aborted channel removal.');
+		}
+	}).catch(() => {
+		// Reply with a failed message
+		message.reply('Aborted channel removal.');
+	});
 
     // Return to stop further processing
     return;

--- a/lib/Commands/channel.ts
+++ b/lib/Commands/channel.ts
@@ -2,13 +2,12 @@
  *
  * N3rdP1um23
  * November 18, 2020
- * The following file is used to handle archiving the respective channel
+ * The following file is used to handle respective channel commands
  *
  */
 
 // Import the requried items
 import * as Discord from 'discord.js';
-import { AnyARecord } from 'dns';
 import * as db from '../../database';
 
 /**
@@ -16,10 +15,10 @@ import * as db from '../../database';
  * The following function is used to handle archiving the respective channel
  *
  * @param message: is the message to handle
- * @param args: is the array of events
+ * @param args: is the array of arguments
  *
  */
-export function archiveChannel(message: Discord.Message, args) {
+export function archive(message: Discord.Message, args) {
     // Check to see if no parameters were passed
 	if(args.length === 1 && (args[0] !== 'true' && args[0] !== 'false')) {
 		// React with a question mark as the user hasn't entered a valid option and then return to stop further processing
@@ -88,9 +87,10 @@ export function archiveChannel(message: Discord.Message, args) {
 		}else{
 			// Create a variable that will hold the clonsed channel
 			var cloned_channel;
+			let clone_channel = args.shift();
 
 			// Check to see if the channel should be cloned
-			if(args[0] === 'true') {
+			if(clone_channel === 'true') {
 				// Clone the channel
 				cloned_channel = await current_channel.clone();
 			}
@@ -105,11 +105,15 @@ export function archiveChannel(message: Discord.Message, args) {
 					fields: [
 						{
 							name: "Was the channel cloned?",
-							value: `${(args[0] === 'true') ? `\`Yes - New Channel\` <#${cloned_channel.id}>` : '\`\`\`No\`\`\`'}`,
+							value: `${(clone_channel === 'true') ? `\`Yes - New Channel\` <#${cloned_channel.id}>` : '\`\`\`No\`\`\`'}`,
 						},
 						{
 							name: "Archived by",
 							value: `<@${message.member.user.id}>`,
+						},
+						{
+							name: "Reason",
+							value: `\`\`\`${(args.length > 0) ? args.join(' ') : 'N/A'}\`\`\``,
 						}
 					]
 				}
@@ -119,6 +123,58 @@ export function archiveChannel(message: Discord.Message, args) {
 			current_channel.setParent(archive_category_channel.id, { lockPermissions: true }).then(() => message.channel.send(archive_embed)).catch(console.error);
 		}
 	});
+
+    // Return to stop further processing
+    return;
+}
+
+/**
+ *
+ * The following function is used to handle cloning the respective channel
+ *
+ * @param message: is the message to handle
+ * @param message: is the passed parameters
+ *
+ */
+export async function clone(message: Discord.Message, args) {
+	// Grab the current channel in question
+	var current_channel = message.guild.channels.cache.find(channel => channel.id === message.channel.id);
+	// Create a variable that will hold the clonsed channel
+	var cloned_channel;
+
+	// Clone the channel
+	cloned_channel = await current_channel.clone();
+
+	// Formulate the clone embed
+	let clone_embed = {
+		embed: {
+			title: `Channel Clonned`,
+			description: `This channel has now been cloned.`,
+			color: 4886754,
+			timestamp: new Date(),
+			fields: [
+				{
+					name: "Cloned from",
+					value: `<#${cloned_channel.id}>`,
+				},
+				{
+					name: "Cloned to",
+					value: `<#${cloned_channel.id}>`,
+				},
+				{
+					name: "Cloned by",
+					value: `<@${message.member.user.id}>`,
+				},
+				{
+					name: "Reason",
+					value: `\`\`\`${(args.length > 0) ? args.join(' ') : 'N/A'}\`\`\``,
+				}
+			]
+		}
+	};
+
+	// Send the notive to the channel
+	message.channel.send(clone_embed);
 
     // Return to stop further processing
     return;

--- a/lib/Commands/index.ts
+++ b/lib/Commands/index.ts
@@ -22,3 +22,4 @@ export * as mute_unmute from './mute_unmute';
 export * as warn from './warn';
 export * as version from './version';
 export * as update from './update';
+export * as archive from './archive';

--- a/lib/Commands/index.ts
+++ b/lib/Commands/index.ts
@@ -22,4 +22,4 @@ export * as mute_unmute from './mute_unmute';
 export * as warn from './warn';
 export * as version from './version';
 export * as update from './update';
-export * as archive from './archive';
+export * as channel from './channel';

--- a/lib/funcs.ts
+++ b/lib/funcs.ts
@@ -68,7 +68,8 @@ export function help(member: Discord.GuildMember, page: number, channel?: Discor
 		tips.push({ 'name': 'Warn User(s)', 'value': '```!warn #rule_num @non_admin_user[]```' });
 		tips.push({ 'name': 'Display bot (repo) version', 'value': '```!version```' });
 		tips.push({ 'name': 'Update bot (repo) version', 'value': '```!update```' });
-		tips.push({ 'name': 'Archive Channel', 'value': '```!archive [clone=false]```' });
+		tips.push({ 'name': 'Archive Channel', 'value': '```!channel archive [clone=false]```' });
+		tips.push({ 'name': 'Clone Channel', 'value': '```!channel clone [clone=false]```' });
 	}
 
 	// Define the max amount of pages  based on the amount of tips

--- a/lib/funcs.ts
+++ b/lib/funcs.ts
@@ -7,6 +7,7 @@
  * Updates
  * -------
  * November 17, 2020 -- N3rdP1um23 -- Added version & update command to the help menu
+ * November 18, 2020 -- N3rdP1um23 -- Added archive command to the help menu
  *
  */
 
@@ -45,7 +46,7 @@ export function help(member: Discord.GuildMember, page: number, channel?: Discor
 	tips.push({ 'name': 'Create Channel', 'value': '```!make channelName```'});
 	tips.push({ 'name': 'User(s\') Info', 'value': '```!info @user[]```' });
 	tips.push({ 'name': 'View RateMyProfessor info', 'value': '```!rmp profName```'});
-	tips.push({ 'name': 'Get days until an event (mainly holiday)', 'value': '```!daysUntil event name```'});
+	tips.push({ 'name': 'Get days until an event (mainly holidays)', 'value': '```!daysUntil event_name[]```'});
 
 	// Check to see if the member has the permission to manage roles
 	if(member.hasPermission(Permissions.FLAGS.MANAGE_ROLES)) {
@@ -67,6 +68,7 @@ export function help(member: Discord.GuildMember, page: number, channel?: Discor
 		tips.push({ 'name': 'Warn User(s)', 'value': '```!warn #rule_num @non_admin_user[]```' });
 		tips.push({ 'name': 'Display bot (repo) version', 'value': '```!version```' });
 		tips.push({ 'name': 'Update bot (repo) version', 'value': '```!update```' });
+		tips.push({ 'name': 'Archive Channel', 'value': '```!archive [recreated=false]```' });
 	}
 
 	// Define the max amount of pages  based on the amount of tips

--- a/lib/funcs.ts
+++ b/lib/funcs.ts
@@ -68,7 +68,7 @@ export function help(member: Discord.GuildMember, page: number, channel?: Discor
 		tips.push({ 'name': 'Warn User(s)', 'value': '```!warn #rule_num @non_admin_user[]```' });
 		tips.push({ 'name': 'Display bot (repo) version', 'value': '```!version```' });
 		tips.push({ 'name': 'Update bot (repo) version', 'value': '```!update```' });
-		tips.push({ 'name': 'Archive Channel', 'value': '```!archive [recreated=false]```' });
+		tips.push({ 'name': 'Archive Channel', 'value': '```!archive [clone=false]```' });
 	}
 
 	// Define the max amount of pages  based on the amount of tips

--- a/lib/funcs.ts
+++ b/lib/funcs.ts
@@ -7,7 +7,7 @@
  * Updates
  * -------
  * November 17, 2020 -- N3rdP1um23 -- Added version & update command to the help menu
- * November 18, 2020 -- N3rdP1um23 -- Added archive command to the help menu
+ * November 18, 2020 -- N3rdP1um23 -- Added channel commands to the help menu
  *
  */
 
@@ -70,6 +70,7 @@ export function help(member: Discord.GuildMember, page: number, channel?: Discor
 		tips.push({ 'name': 'Update bot (repo) version', 'value': '```!update```' });
 		tips.push({ 'name': 'Archive Channel', 'value': '```!channel archive [clone=false]```' });
 		tips.push({ 'name': 'Clone Channel', 'value': '```!channel clone [clone=false]```' });
+		tips.push({ 'name': 'Clone Channel', 'value': '```!channel remove```' });
 	}
 
 	// Define the max amount of pages  based on the amount of tips

--- a/lib/handlers/messages.ts
+++ b/lib/handlers/messages.ts
@@ -8,7 +8,7 @@
  * -------
  * November 1, 2020 -- N3rdP1um23 -- Updated execution of commands and cleaned up file, updated the cbp to be a random number between 1-500
  * November 17, 2020 -- N3rdP1um23 -- Added version & update commands
- * November 18, 2020 -- N3rdP1um23 -- Added archive command
+ * November 18, 2020 -- N3rdP1um23 -- Added channel commands
  *
  */
 
@@ -184,12 +184,12 @@ export function handleMessage(message: Discord.Message) {
 				let action = args.shift();
 
 				// Check to see if the action argument is valid
-				if(['archive', 'clone'].includes(action)) {
+				if(['archive', 'clone', 'remove'].includes(action)) {
 					// Execute the respective action
 					commands['channel'][action](message, args);
 				}else{
 					// Send an error message
-					message.channel.send('Oops... Missing channel action to execute.');
+					message.channel.send('Oops... Missing/wrong channel action to execute.');
 				}
 
 				// Return to stop further processing

--- a/lib/handlers/messages.ts
+++ b/lib/handlers/messages.ts
@@ -7,6 +7,8 @@
  * Updates
  * -------
  * November 1, 2020 -- N3rdP1um23 -- Updated execution of commands and cleaned up file, updated the cbp to be a random number between 1-500
+ * November 17, 2020 -- N3rdP1um23 -- Added version & update commands
+ * November 18, 2020 -- N3rdP1um23 -- Added archive command
  *
  */
 
@@ -175,11 +177,18 @@ export function handleMessage(message: Discord.Message) {
 				commands['update'].updateBot(message);
 				return;
 			}
+
+			// Check to see if the user is executing the archive command
+			if(command === 'archive') {
+				// Call the help command and return to stop further processing
+				commands['archive'].archiveChannel(message, args);
+				return;
+			}
 		}
 	}
 
 	// Check to see if someone flipped a table or used the table flip command
-	if(raw_message.startsWith('(╯°□°）╯︵ ┻━┻') || raw_message.startsWith('/tableflip')) {
+	if(raw_message.includes('(╯°□°）╯︵ ┻━┻') || raw_message.includes('/tableflip')) {
 		// Unflip the table
 		message.channel.send('┬─┬ ノ( ゜-゜ノ)');
 	}

--- a/lib/handlers/messages.ts
+++ b/lib/handlers/messages.ts
@@ -178,10 +178,21 @@ export function handleMessage(message: Discord.Message) {
 				return;
 			}
 
-			// Check to see if the user is executing the archive command
-			if(command === 'archive') {
-				// Call the help command and return to stop further processing
-				commands['archive'].archiveChannel(message, args);
+			// Check to see if the user is executing the channel command
+			if(command === 'channel') {
+				// Create a variable that will hold the action value
+				let action = args.shift();
+
+				// Check to see if the action argument is valid
+				if(['archive', 'clone'].includes(action)) {
+					// Execute the respective action
+					commands['channel'][action](message, args);
+				}else{
+					// Send an error message
+					message.channel.send('Oops... Missing channel action to execute.');
+				}
+
+				// Return to stop further processing
 				return;
 			}
 		}


### PR DESCRIPTION
Added new channel helper commands for admins

- Archive channel `!channel archive [clone(true|**false**)] [reason]`
- Clone channel `!channel clone [reason]`
- Remove channel `!channel remove` - admin issuing command will need to confirm with the bot their intention to remove the channel within 30s of issuing the command for it to actually execute